### PR TITLE
fix: #23 rethink NN canvas positioning so it reliably fills its container

### DIFF
--- a/layouts/partials/custom/neural-network.html
+++ b/layouts/partials/custom/neural-network.html
@@ -2,7 +2,7 @@
 .neural-net-wrapper {
     margin: 0;
     width: 100%;
-    height: 100%;
+    flex: 1;
     box-sizing: border-box;
     background: var(--color-background-code, rgba(128, 128, 128, 0.05));
     border: 1px solid var(--color-border, rgba(128, 128, 128, 0.15));
@@ -12,8 +12,6 @@
     overflow: hidden;
     min-height: 260px;
     transition: transform 0.3s ease, box-shadow 0.3s ease;
-    display: flex;
-    flex-direction: column;
 }
 
 .neural-net-wrapper:hover {
@@ -21,14 +19,21 @@
     box-shadow: 0 10px 30px rgba(0, 0, 0, 0.05);
 }
 
+/* Canvas fills the wrapper by CSS geometry — no JS measurement needed */
 .neural-net-wrapper canvas {
-    flex: 1;
-    width: 100%;
+    position: absolute;
+    inset: 0;
     display: block;
     cursor: crosshair;
 }
 
 .nn-tooltip {
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    z-index: 1;
+    pointer-events: none;
     height: 28px;
     display: flex;
     align-items: center;
@@ -64,15 +69,27 @@ document.addEventListener("DOMContentLoaded", function() {
 
     let width = 0, height = 0;
 
+    // Read from the container (CSS-sized) — canvas.getBoundingClientRect()
+    // returns 0×0 until paint; container.clientWidth/Height are stable once
+    // the flex layout is committed.
     function resize() {
-        const rect = canvas.getBoundingClientRect();
-        width = rect.width || container.clientWidth;
-        height = rect.height || (container.clientHeight - 28);
-        canvas.width = width;
+        width  = container.clientWidth;
+        height = container.clientHeight;
+        canvas.width  = width;
         canvas.height = height;
     }
+
+    // Two RAFs: first lets the browser flush layout, second commits dimensions.
+    requestAnimationFrame(function() {
+        requestAnimationFrame(function() {
+            resize();
+        });
+    });
+
     window.addEventListener('resize', function() { resize(); initialized = false; });
-    setTimeout(resize, 50);
+    if (typeof ResizeObserver !== 'undefined') {
+        new ResizeObserver(function() { resize(); initialized = false; }).observe(container);
+    }
 
     // Architecture: specific experiences → extracted skills → domains → current roles
     const layers = [


### PR DESCRIPTION
## Summary

- Canvas is `position: absolute; inset: 0` — CSS geometry owns the size, not JS measurement
- `resize()` reads `container.clientWidth/clientHeight` (stable once flex layout commits) instead of `canvas.getBoundingClientRect()` which returns `0×0` until after first paint
- Initial `resize()` call deferred to two nested `requestAnimationFrame` callbacks, ensuring browser has flushed and committed layout before dimensions are read
- `ResizeObserver` retained for live window-resize handling
- Tooltip repositioned to `position: absolute; bottom: 0` with `z-index: 1` so it floats above the canvas without occupying flex flow space
- Removed `display: flex; flex-direction: column` from wrapper (no longer needed — canvas and tooltip are both absolutely positioned)

## Acceptance criteria

- [x] Nodes evenly distributed across full widget height, matching the "Currently Processing" card
- [x] No positional jump on first hover
- [x] Correct layout after window resize

Closes #23